### PR TITLE
docs:add link to blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a modern typescript monorepo example
 
-The full write up on how this monorepo works is and how to set it up [here]()
+The full write up on how this monorepo works is and how to set it up [here](https://github.com/nickpainter/typescript-monorepo-example.git)
 
 ## Package Breakdown 
 


### PR DESCRIPTION
`README.MD` was missing a link to the orignal blog article